### PR TITLE
Fix infinite recursion in macro expansion (bug1324765)

### DIFF
--- a/src/compiler/preprocessor/MacroExpander.h
+++ b/src/compiler/preprocessor/MacroExpander.h
@@ -84,6 +84,11 @@ class MacroExpander : public Lexer
 
     std::unique_ptr<Token> mReserveToken;
     std::vector<MacroContext *> mContextStack;
+
+    bool mDeferReenablingMacros;
+    std::vector<const Macro *> mMacrosToReenable;
+
+    class ScopedMacroReenabler;
 };
 
 }  // namespace pp

--- a/src/tests/preprocessor_tests/define_test.cpp
+++ b/src/tests/preprocessor_tests/define_test.cpp
@@ -939,3 +939,18 @@ TEST_F(DefineTest, NegativeShiftInLineDirective)
     EXPECT_CALL(mDiagnostics, print(pp::Diagnostics::PP_INVALID_LINE_NUMBER, _, _)).Times(2);
     preprocess(input, expected);
 }
+
+// The name of the macro "a" is inside an incomplete macro invocation of macro "m()" in its own
+// expansion. This should not result in infinite recursion.
+TEST_F(DefineTest, RecursiveMacroNameInsideIncompleteMacroInvocationInMacroExpansion)
+{
+    const char *input =
+        "#define m(a)\n"
+        "#define a m((a)\n"
+        "a)\n";
+    const char *expected =
+        "\n"
+        "\n"
+        "\n";
+    preprocess(input, expected);
+}


### PR DESCRIPTION
Fix infinite recursion in macro expansion by cherry-picking fix in newer version of ANGLE.

BUG=angleproject:1600
TEST=angle_unittests

Change-Id: I72bf81ec060f36255a0f13b132a4fd69b89672ff
Reviewed-on: https://chromium-review.googlesource.com/412744
Commit-Queue: Olli Etuaho <oetuaho@nvidia.com>
Reviewed-by: Jamie Madill <jmadill@chromium.org>