### PR TITLE
Fix occasional corruption of vertex textures in HD4600 GPUs.

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
@@ -2414,6 +2414,9 @@ angle::WorkaroundsD3D GenerateWorkarounds(const Renderer11DeviceCaps &deviceCaps
         else if (IsBroadwell(adapterDesc.DeviceId) || IsHaswell(adapterDesc.DeviceId))
         {
             workarounds.rewriteUnaryMinusOperator = capsVersion < IntelDriverVersion(4624);
+
+            // Haswell drivers occasionally corrupt (small?) (vertex?) texture data uploads.
+            workarounds.setDataFasterThanImageUpload = false;
         }
     }
 


### PR DESCRIPTION
This appears to be caused by the UpdateSubResource
call, which is worked around by using the other image upload
path that ANGLE supports.

The workaround doesn't include a driver version, since the
bug is occurring in the most recent driver that is currently
available (15.40.42.5063, released 19th Mar 2019).