### PR TITLE
use image upload workaround for Intel Ivy Bridge with D3D11 renderer

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
@@ -2426,7 +2426,8 @@ void InitializeFeatures(const Renderer11DeviceCaps &deviceCaps,
             features->callClearTwice.enabled    = capsVersion < IntelDriverVersion(4771);
             features->emulateIsnanFloat.enabled = capsVersion < IntelDriverVersion(4542);
         }
-        else if (IsBroadwell(adapterDesc.DeviceId) || IsHaswell(adapterDesc.DeviceId))
+        else if (IsBroadwell(adapterDesc.DeviceId) || IsHaswell(adapterDesc.DeviceId) ||
+                 IsIvyBridge(adapterDesc.DeviceId))
         {
             features->rewriteUnaryMinusOperator.enabled = capsVersion < IntelDriverVersion(4624);
 

--- a/src/libANGLE/renderer/driver_utils.cpp
+++ b/src/libANGLE/renderer/driver_utils.cpp
@@ -23,6 +23,8 @@ namespace rx
 namespace
 {
 // gen7
+const uint32_t IvyBridge[] = {0x0152, 0x0156, 0x015A, 0x0162, 0x0166, 0x016A};
+
 const uint32_t Haswell[] = {
     0x0402, 0x0406, 0x040A, 0x040B, 0x040E, 0x0C02, 0x0C06, 0x0C0A, 0x0C0B, 0x0C0E,
     0x0A02, 0x0A06, 0x0A0A, 0x0A0B, 0x0A0E, 0x0D02, 0x0D06, 0x0D0A, 0x0D0B, 0x0D0E,  // hsw_gt1
@@ -88,6 +90,11 @@ bool IntelDriverVersion::operator<(const IntelDriverVersion &version)
 bool IntelDriverVersion::operator>=(const IntelDriverVersion &version)
 {
     return !(*this < version);
+}
+
+bool IsIvyBridge(uint32_t DeviceId)
+{
+    return std::find(std::begin(IvyBridge), std::end(IvyBridge), DeviceId) != std::end(IvyBridge);
 }
 
 bool IsHaswell(uint32_t DeviceId)

--- a/src/libANGLE/renderer/driver_utils.h
+++ b/src/libANGLE/renderer/driver_utils.h
@@ -94,6 +94,7 @@ class IntelDriverVersion
     uint16_t mVersionPart;
 };
 
+bool IsIvyBridge(uint32_t DeviceId);
 bool IsHaswell(uint32_t DeviceId);
 bool IsBroadwell(uint32_t DeviceId);
 bool IsCherryView(uint32_t DeviceId);


### PR DESCRIPTION
Ivy Bridge hardware displays the same unfortunate behavior as Haswell. Enabling the same fix used for Haswell resolves the issue.