### PR TITLE
Restrict the slow texture upload workaround to 128bit formats.

### DIFF
--- a/include/platform/FeaturesD3D.h
+++ b/include/platform/FeaturesD3D.h
@@ -43,6 +43,10 @@ struct FeaturesD3D : FeatureSetBase
                                             FeatureCategory::D3DWorkarounds,
                                             "Set data faster than image upload", &members};
 
+    Feature setDataFasterThanImageUploadOn128bitFormats = {
+        "set_data_faster_than_image_upload_on_128bit_formats", FeatureCategory::D3DWorkarounds,
+        "Set data faster than image upload on 128bit formats", &members};
+
     // Some renderers can't disable mipmaps on a mipmapped texture (i.e. solely sample from level
     // zero, and ignore the other levels). D3D11 Feature Level 10+ does this by setting MaxLOD to
     // 0.0f in the Sampler state. D3D9 sets D3DSAMP_MIPFILTER to D3DTEXF_NONE. There is no

--- a/src/libANGLE/renderer/d3d/TextureD3D.cpp
+++ b/src/libANGLE/renderer/d3d/TextureD3D.cpp
@@ -196,9 +196,25 @@ angle::Result TextureD3D::setStorageExternalMemory(const gl::Context *context,
     return angle::Result::Continue;
 }
 
-bool TextureD3D::shouldUseSetData(const ImageD3D *image) const
+bool TextureD3D::couldUseSetData() const
 {
     if (!mRenderer->getFeatures().setDataFasterThanImageUpload.enabled)
+    {
+        return false;
+    }
+
+    if (!mRenderer->getFeatures().setDataFasterThanImageUploadOn128bitFormats.enabled)
+    {
+        gl::InternalFormat internalFormat = gl::GetSizedInternalFormatInfo(getBaseLevelInternalFormat());
+        return internalFormat.pixelBytes < 16;
+    }
+
+    return true;
+}
+
+bool TextureD3D::shouldUseSetData(const ImageD3D *image) const
+{
+    if (!couldUseSetData())
     {
         return false;
     }
@@ -474,7 +490,7 @@ angle::Result TextureD3D::generateMipmapUsingImages(const gl::Context *context,
     // When making mipmaps with the setData workaround enabled, the texture storage has
     // the image data already. For non-render-target storage, we have to pull it out into
     // an image layer.
-    if (mRenderer->getFeatures().setDataFasterThanImageUpload.enabled && mTexStorage)
+    if (mTexStorage && couldUseSetData())
     {
         if (!mTexStorage->isRenderTarget())
         {

--- a/src/libANGLE/renderer/d3d/TextureD3D.h
+++ b/src/libANGLE/renderer/d3d/TextureD3D.h
@@ -186,6 +186,7 @@ class TextureD3D : public TextureImpl
 
     virtual angle::Result updateStorage(const gl::Context *context) = 0;
 
+    bool couldUseSetData() const;
     bool shouldUseSetData(const ImageD3D *image) const;
 
     angle::Result generateMipmapUsingImages(const gl::Context *context, const GLuint maxLevel);

--- a/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
@@ -2383,10 +2383,11 @@ void InitializeFeatures(const Renderer11DeviceCaps &deviceCaps,
 {
     bool is9_3 = (deviceCaps.featureLevel <= D3D_FEATURE_LEVEL_9_3);
 
-    features->mrtPerfWorkaround.enabled                = true;
-    features->setDataFasterThanImageUpload.enabled     = true;
-    features->zeroMaxLodWorkaround.enabled             = is9_3;
-    features->useInstancedPointSpriteEmulation.enabled = is9_3;
+    features->mrtPerfWorkaround.enabled                           = true;
+    features->setDataFasterThanImageUpload.enabled                = true;
+    features->setDataFasterThanImageUploadOn128bitFormats.enabled = true;
+    features->zeroMaxLodWorkaround.enabled                        = is9_3;
+    features->useInstancedPointSpriteEmulation.enabled            = is9_3;
 
     // TODO(jmadill): Narrow problematic driver range.
     if (IsNvidia(adapterDesc.VendorId))
@@ -2430,8 +2431,8 @@ void InitializeFeatures(const Renderer11DeviceCaps &deviceCaps,
         {
             features->rewriteUnaryMinusOperator.enabled = capsVersion < IntelDriverVersion(4624);
 
-            // Haswell drivers occasionally corrupt (small?) (vertex?) texture data uploads.
-            features->setDataFasterThanImageUpload.enabled = false;
+            // Haswell drivers occasionally corrupt (small?) (vertex?) texture data uploads for 128bit formats.
+            features->setDataFasterThanImageUploadOn128bitFormats.enabled = false;
         }
     }
 

--- a/src/libANGLE/renderer/d3d/d3d9/renderer9_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d9/renderer9_utils.cpp
@@ -805,9 +805,10 @@ void MakeValidSize(bool isImage,
 
 void InitializeFeatures(angle::FeaturesD3D *features)
 {
-    features->mrtPerfWorkaround.enabled                = true;
-    features->setDataFasterThanImageUpload.enabled     = false;
-    features->useInstancedPointSpriteEmulation.enabled = false;
+    features->mrtPerfWorkaround.enabled                           = true;
+    features->setDataFasterThanImageUpload.enabled                = false;
+    features->setDataFasterThanImageUploadOn128bitFormats.enabled = false;
+    features->useInstancedPointSpriteEmulation.enabled            = false;
 
     // TODO(jmadill): Disable workaround when we have a fixed compiler DLL.
     features->expandIntegerPowExpressions.enabled = true;


### PR DESCRIPTION
The workaround is slow for having a CPU-visible mirror of the texture, but that mirror is not properly recycled with regards to GPU usage, thus causing a CPU stall on update.

Original reports were related to WebRender vertex texture updates that are RGBA32F and RGBA32U formats. Limiting the workaround to these formats would allow the affected platforms to upload regular texture data faster without stalls.

Related to https://bugzilla.mozilla.org/show_bug.cgi?id=1585404