### PR TITLE
Don't use ClearView if we previously used dual source blending on Intel gen6

### DIFF
--- a/include/platform/FeaturesD3D.h
+++ b/include/platform/FeaturesD3D.h
@@ -155,6 +155,14 @@ struct FeaturesD3D : FeatureSetBase
                               "On some Intel drivers, using clear() may not take effect", &members,
                               "https://crbug.com/655534"};
 
+    // On Sandybridge, calling ClearView after using dual source blending causes the hardware to hang.
+    // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1633628
+    Feature emulateClearViewAfterDualSourceBlending = {"emulate_clear_view_after_dual_source_blending",
+                              FeatureCategory::D3DWorkarounds,
+                              "On Sandybridge, calling ClearView after using dual source blending causes "
+                              "the hardware to hang", &members,
+                              "https://bugzilla.mozilla.org/show_bug.cgi?id=1633628"};
+
     // On some Intel drivers, copying from staging storage to constant buffer storage does not
     // seem to work. Work around this by keeping system memory storage as a canonical reference
     // for buffer data.

--- a/src/libANGLE/renderer/d3d/d3d11/Clear11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Clear11.cpp
@@ -505,7 +505,34 @@ angle::Result Clear11::clearFramebuffer(const gl::Context *context,
         const auto &framebufferRTV = renderTarget->getRenderTargetView();
         ASSERT(framebufferRTV.valid());
 
-        if ((!(mRenderer->getRenderer11DeviceCaps().supportsClearView) && needScissoredClear) ||
+        bool canClearView = true;
+        if (mRenderer->getFeatures().emulateClearViewAfterDualSourceBlending.enabled) {
+            // Check the current state to see if we were using dual source blending
+            auto isDualSource = [](auto blend) { switch (blend) {
+                        case D3D11_BLEND_SRC1_COLOR:
+                        case D3D11_BLEND_INV_SRC1_COLOR:
+                        case D3D11_BLEND_SRC1_ALPHA:
+                        case D3D11_BLEND_INV_SRC1_ALPHA:
+                                return true;
+                        default:
+                                return false;
+            }};
+            FLOAT blendFactor[4];
+            UINT sampleMask;
+            ID3D11BlendState *blendState;
+            D3D11_BLEND_DESC blendDesc;
+            deviceContext1->OMGetBlendState(&blendState, blendFactor, &sampleMask);
+            blendState->GetDesc(&blendDesc);
+            // You can only use dual source blending on slot 0 so only check there
+            if (isDualSource(blendDesc.RenderTarget[0].SrcBlend) ||
+                isDualSource(blendDesc.RenderTarget[0].DestBlend) ||
+                isDualSource(blendDesc.RenderTarget[0].SrcBlendAlpha) ||
+                isDualSource(blendDesc.RenderTarget[0].DestBlendAlpha)) {
+                canClearView = false;
+            }
+        }
+
+        if ((!(mRenderer->getRenderer11DeviceCaps().supportsClearView && canClearView) && needScissoredClear) ||
             clearParams.colorType != GL_FLOAT ||
             (formatInfo.redBits > 0 && !clearParams.colorMaskRed) ||
             (formatInfo.greenBits > 0 && !clearParams.colorMaskGreen) ||

--- a/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
@@ -2435,7 +2435,9 @@ void InitializeFeatures(const Renderer11DeviceCaps &deviceCaps,
             // Haswell drivers occasionally corrupt (small?) (vertex?) texture data uploads for
             // 128bit formats.
             features->setDataFasterThanImageUploadOn128bitFormats.enabled = false;
-        }
+        } else if (IsSandyBridge(adapterDesc.DeviceId)) {
+	    features->emulateClearViewAfterDualSourceBlending.enabled = true;
+	}
     }
 
     if (IsAMD(adapterDesc.VendorId))

--- a/src/libANGLE/renderer/driver_utils.cpp
+++ b/src/libANGLE/renderer/driver_utils.cpp
@@ -22,6 +22,9 @@ namespace rx
 // Referenced from https://cgit.freedesktop.org/vaapi/intel-driver/tree/src/i965_pciids.h
 namespace
 {
+// gen6
+const uint32_t SandyBridge[] = {0x0102, 0x0106, 0x010A, 0x0112, 0x0116, 0x0122, 0x0126};
+
 // gen7
 const uint32_t IvyBridge[] = {0x0152, 0x0156, 0x015A, 0x0162, 0x0166, 0x016A};
 
@@ -90,6 +93,11 @@ bool IntelDriverVersion::operator<(const IntelDriverVersion &version)
 bool IntelDriverVersion::operator>=(const IntelDriverVersion &version)
 {
     return !(*this < version);
+}
+
+bool IsSandyBridge(uint32_t DeviceId)
+{
+    return std::find(std::begin(SandyBridge), std::end(SandyBridge), DeviceId) != std::end(SandyBridge);
 }
 
 bool IsIvyBridge(uint32_t DeviceId)

--- a/src/libANGLE/renderer/driver_utils.h
+++ b/src/libANGLE/renderer/driver_utils.h
@@ -94,6 +94,7 @@ class IntelDriverVersion
     uint16_t mVersionPart;
 };
 
+bool IsSandyBridge(uint32_t DeviceId);
 bool IsIvyBridge(uint32_t DeviceId);
 bool IsHaswell(uint32_t DeviceId);
 bool IsBroadwell(uint32_t DeviceId);


### PR DESCRIPTION
Doing a ClearView after a dual source blend seems to cause a TDR on
Intel SandyBridge. Presumeably this is because the ClearView is
implemented as a regular draw and the driver doesn't properly set up the
state.

If we detect that this is going to happen we fall back to the manual
draw call path. This lets us use ClearView most of the time still.