### PR TITLE
Use deviceContext instead of deviceContext1

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/Clear11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Clear11.cpp
@@ -521,7 +521,7 @@ angle::Result Clear11::clearFramebuffer(const gl::Context *context,
             UINT sampleMask;
             ID3D11BlendState *blendState;
             D3D11_BLEND_DESC blendDesc;
-            deviceContext1->OMGetBlendState(&blendState, blendFactor, &sampleMask);
+            deviceContext->OMGetBlendState(&blendState, blendFactor, &sampleMask);
             if (blendState) {
                     blendState->GetDesc(&blendDesc);
                     // You can only use dual source blending on slot 0 so only check there


### PR DESCRIPTION
Sometimes we don't have a deviceContext1 (on Win7) and would crash. We
on't have any need to use it so just use deviceContext.