### PR TITLE
Qualify TIntermPreprocessorDirective as final

### DIFF
--- a/src/compiler/translator/IntermNode.h
+++ b/src/compiler/translator/IntermNode.h
@@ -908,12 +908,12 @@ enum class PreprocessorDirective
     Endif,
 };
 
-class TIntermPreprocessorDirective : public TIntermNode
+class TIntermPreprocessorDirective final : public TIntermNode
 {
   public:
     // This could also take an ImmutbleString as an argument.
     TIntermPreprocessorDirective(PreprocessorDirective directive, ImmutableString command);
-    ~TIntermPreprocessorDirective() final;
+    ~TIntermPreprocessorDirective();
 
     void traverse(TIntermTraverser *it) final;
     bool visit(Visit visit, TIntermTraverser *it) final;


### PR DESCRIPTION
While building Firefox, this is printed many times

```
55:44.99 In file included from /Users/m/Downloads/gecko/gfx/angle/checkout/src/compiler/translator/tree_util/IntermNodePatternMatcher.cpp:13:
55:44.99 /Users/m/Downloads/gecko/gfx/angle/checkout/src/compiler/translator/IntermNode.h:916:37: warning: class with destructor marked 'final' cannot be inherited from [-Wfinal-dtor-non-final-class]
55:44.99     ~TIntermPreprocessorDirective() final;
55:44.99                                     ^
55:44.99 /Users/m/Downloads/gecko/gfx/angle/checkout/src/compiler/translator/IntermNode.h:911:7: note: mark 'sh::TIntermPreprocessorDirective' as 'final' to silence this warning
55:44.99 class TIntermPreprocessorDirective : public TIntermNode
55:44.99  
```

Complies with the coding style:

> {DO} use C++11/14 according to the [Chromium c++ 11/14 guide] (http://chromium-cpp.appspot.com/).