### PR TITLE
Disable ClearView with scissor on Skylake iGPU because of observed bugs

### DIFF
--- a/include/platform/FeaturesD3D_autogen.h
+++ b/include/platform/FeaturesD3D_autogen.h
@@ -128,6 +128,13 @@ struct FeaturesD3D : FeatureSetBase
         "hang",
         &members, "https://bugzilla.mozilla.org/show_bug.cgi?id=1633628"};
 
+    FeatureInfo scissoredClearArtifacts = {
+        "scissoredClearArtifacts", FeatureCategory::D3DWorkarounds,
+        "On Skylake, calling ClearView with a scissor rect that is not a multiple of 8x4 pixels "
+        "causes corruption of pixels in the 8x4 pixel tiles along the edge which resembles a "
+        "square wave",
+        &members, "https://bugzilla.mozilla.org/show_bug.cgi?id=1817240"};
+
     FeatureInfo useSystemMemoryForConstantBuffers = {
         "useSystemMemoryForConstantBuffers", FeatureCategory::D3DWorkarounds,
         "Copying from staging storage to constant buffer "

--- a/include/platform/d3d_features.json
+++ b/include/platform/d3d_features.json
@@ -129,6 +129,14 @@
             "issue": "https://bugzilla.mozilla.org/show_bug.cgi?id=1633628"
         },
         {
+            "name": "scissored_clear_artifacts",
+            "category": "Workarounds",
+            "description": [
+                "On Skylake, calling ClearView with a scissor rect that is not a multiple of 8x4 pixels causes corruption of pixels in the 8x4 pixel tiles along the edge which resembles a square wave"
+            ],
+            "issue": "https://bugzilla.mozilla.org/show_bug.cgi?id=1817240"
+        },
+        {
             "name": "use_system_memory_for_constant_buffers",
             "category": "Workarounds",
             "description": [

--- a/src/libANGLE/renderer/d3d/d3d11/Clear11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Clear11.cpp
@@ -537,6 +537,11 @@ angle::Result Clear11::clearFramebuffer(const gl::Context *context,
             }
         }
 
+        if (needScissoredClear && mRenderer->getFeatures().scissoredClearArtifacts.enabled)
+        {
+            canClearView = false;
+        }
+
         if ((!canClearView && needScissoredClear) || clearParams.colorType != GL_FLOAT ||
             (formatInfo.redBits > 0 && !r) || (formatInfo.greenBits > 0 && !g) ||
             (formatInfo.blueBits > 0 && !b) || (formatInfo.alphaBits > 0 && !a))

--- a/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp
@@ -2512,6 +2512,10 @@ void InitializeFeatures(const Renderer11DeviceCaps &deviceCaps,
     ANGLE_FEATURE_CONDITION(features, preAddTexelFetchOffsets, isIntel);
     ANGLE_FEATURE_CONDITION(features, useSystemMemoryForConstantBuffers, isIntel);
 
+    // ClearView on Skylake seems to incorrectly clear with unaligned rects (edge has saw tooth
+    // pattern instead of straight).
+    ANGLE_FEATURE_CONDITION(features, scissoredClearArtifacts, isIntel && isSkylake);
+
     ANGLE_FEATURE_CONDITION(features, callClearTwice,
                             isIntel && isSkylake && capsVersion >= IntelDriverVersion(160000) &&
                                 capsVersion < IntelDriverVersion(164771));


### PR DESCRIPTION
We saw jagged edges on ClearView with rects that are not aligned to some unknown grid (probably 8x4), since this not only fails to correctly clear the rect but also damages regions outside the rect it's not really usable.