### PR TITLE
handle Qualcomm's mixed vendor IDs

### DIFF
--- a/src/gpu_info_util/SystemInfo.cpp
+++ b/src/gpu_info_util/SystemInfo.cpp
@@ -45,6 +45,7 @@ std::string VendorName(VendorID vendor)
         case kVendorID_NVIDIA:
             return "NVIDIA";
         case kVendorID_Qualcomm:
+        case kVendorID_Qualcomm_DXGI:
             return "Qualcomm";
         case kVendorID_VeriSilicon:
             return "VeriSilicon";

--- a/src/gpu_info_util/SystemInfo.h
+++ b/src/gpu_info_util/SystemInfo.h
@@ -101,17 +101,18 @@ bool GetSystemInfo(SystemInfo *info);
 bool GetSystemInfoVulkan(SystemInfo *info);
 
 // Known PCI vendor IDs
-constexpr VendorID kVendorID_AMD       = 0x1002;
-constexpr VendorID kVendorID_ARM       = 0x13B5;
-constexpr VendorID kVendorID_Broadcom  = 0x14E4;
-constexpr VendorID kVendorID_GOOGLE    = 0x1AE0;
-constexpr VendorID kVendorID_ImgTec    = 0x1010;
-constexpr VendorID kVendorID_Intel     = 0x8086;
-constexpr VendorID kVendorID_NVIDIA    = 0x10DE;
-constexpr VendorID kVendorID_Qualcomm  = 0x5143;
-constexpr VendorID kVendorID_VMWare    = 0x15ad;
-constexpr VendorID kVendorID_Apple     = 0x106B;
-constexpr VendorID kVendorID_Microsoft = 0x1414;
+constexpr VendorID kVendorID_AMD           = 0x1002;
+constexpr VendorID kVendorID_ARM           = 0x13B5;
+constexpr VendorID kVendorID_Broadcom      = 0x14E4;
+constexpr VendorID kVendorID_GOOGLE        = 0x1AE0;
+constexpr VendorID kVendorID_ImgTec        = 0x1010;
+constexpr VendorID kVendorID_Intel         = 0x8086;
+constexpr VendorID kVendorID_NVIDIA        = 0x10DE;
+constexpr VendorID kVendorID_Qualcomm      = 0x5143;
+constexpr VendorID kVendorID_Qualcomm_DXGI = 0x4D4F4351;
+constexpr VendorID kVendorID_VMWare        = 0x15ad;
+constexpr VendorID kVendorID_Apple         = 0x106B;
+constexpr VendorID kVendorID_Microsoft     = 0x1414;
 
 // Known non-PCI (i.e. Khronos-registered) vendor IDs
 constexpr VendorID kVendorID_Vivante     = 0x10001;

--- a/src/gpu_info_util/SystemInfo_vulkan.cpp
+++ b/src/gpu_info_util/SystemInfo_vulkan.cpp
@@ -239,6 +239,7 @@ bool GetSystemInfoVulkanWithICD(SystemInfo *info, vk::ICD preferredICD)
                 gpu.detailedDriverVersion.patch    = properties.driverVersion & 0x3F;
                 break;
             case kVendorID_Qualcomm:
+            case kVendorID_Qualcomm_DXGI:
                 gpu.driverVendor = "Qualcomm Technologies, Inc";
                 if (properties.driverVersion & 0x80000000)
                 {

--- a/src/libANGLE/renderer/driver_utils.cpp
+++ b/src/libANGLE/renderer/driver_utils.cpp
@@ -264,6 +264,7 @@ const char *GetVendorString(uint32_t vendorId)
             return "NVIDIA";
         case VENDOR_ID_POWERVR:
             return "Imagination Technologies";
+        case VENDOR_ID_QUALCOMM_DXGI:
         case VENDOR_ID_QUALCOMM:
             return "Qualcomm";
         case VENDOR_ID_SAMSUNG:

--- a/src/libANGLE/renderer/driver_utils.h
+++ b/src/libANGLE/renderer/driver_utils.h
@@ -22,19 +22,18 @@ enum VendorID : uint32_t
     VENDOR_ID_APPLE   = 0x106B,
     VENDOR_ID_ARM     = 0x13B5,
     // Broadcom devices won't use PCI, but this is their Vulkan vendor id.
-    VENDOR_ID_BROADCOM  = 0x14E4,
-    VENDOR_ID_GOOGLE    = 0x1AE0,
-    VENDOR_ID_INTEL     = 0x8086,
-    VENDOR_ID_MESA      = 0x10005,
-    VENDOR_ID_MICROSOFT = 0x1414,
-    VENDOR_ID_NVIDIA    = 0x10DE,
-    VENDOR_ID_POWERVR   = 0x1010,
-    // This is Qualcomm PCI Vendor ID.
-    // Android doesn't have a PCI bus, but all we need is a unique id.
-    VENDOR_ID_QUALCOMM = 0x5143,
-    VENDOR_ID_SAMSUNG  = 0x144D,
-    VENDOR_ID_VIVANTE  = 0x9999,
-    VENDOR_ID_VMWARE   = 0x15AD,
+    VENDOR_ID_BROADCOM      = 0x14E4,
+    VENDOR_ID_GOOGLE        = 0x1AE0,
+    VENDOR_ID_INTEL         = 0x8086,
+    VENDOR_ID_MESA          = 0x10005,
+    VENDOR_ID_MICROSOFT     = 0x1414,
+    VENDOR_ID_NVIDIA        = 0x10DE,
+    VENDOR_ID_POWERVR       = 0x1010,
+    VENDOR_ID_QUALCOMM_DXGI = 0x4D4F4351,
+    VENDOR_ID_QUALCOMM      = 0x5143,
+    VENDOR_ID_SAMSUNG       = 0x144D,
+    VENDOR_ID_VIVANTE       = 0x9999,
+    VENDOR_ID_VMWARE        = 0x15AD,
 };
 
 enum AndroidDeviceID : uint32_t
@@ -94,7 +93,14 @@ inline bool IsPowerVR(uint32_t vendorId)
 
 inline bool IsQualcomm(uint32_t vendorId)
 {
-    return vendorId == VENDOR_ID_QUALCOMM;
+    // Qualcomm is an unusual one. It has two different vendor IDs depending on
+    // where you look. On Windows, DXGI will report the VENDOR_ID_QUALCOMM_DXGI
+    // value (due to it being an ACPI device rather than PCI device), but their
+    // native Vulkan driver will actually report their PCI vendor ID (the
+    // VENDOR_ID_QUALCOMM value). So we have to check both, to ensure we arrive
+    // at the right conclusion regardless of what source we are querying for
+    // vendor information.
+    return vendorId == VENDOR_ID_QUALCOMM || vendorId == VENDOR_ID_QUALCOMM_DXGI;
 }
 
 inline bool IsSamsung(uint32_t vendorId)


### PR DESCRIPTION
This is a weird situation. Up until Qualcomm had a native Vulkan driver for Windows (with the Snapdragon X series chips), the only vendor ID observable on Windows was 0x4D4F4351. This was reported through DXGI, device manager, etc.

But with their native Vulkan driver, they now report 0x5143 as well:

    VkPhysicalDeviceProperties:
    ---------------------------
        apiVersion        = 1.3.295 (4206887)
        driverVersion     = 0.807.0 (2150789120)
        vendorID          = 0x5143
        deviceID          = 0x36334330
        deviceType        = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
        deviceName        = Qualcomm(R) Adreno(TM) X1-85 GPU
        pipelineCacheUUID = 0eba4509-4351-0000-0000-010c05430000

And yet, DXGI still reports 0x4D4F4351. Cool, huh?

Let's teach IsQualcomm to understand both vendor IDs to ensure the device is correctly detected as a tile-based renderer in the Vulkan backend.

Bug: angleproject:390866623
Change-Id: I9170c30262ace269498f066e922a279c7e981de6
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/6183621
Reviewed-by: Geoff Lang <geofflang@chromium.org>
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
Commit-Queue: Geoff Lang <geofflang@chromium.org>
Auto-Submit: Steven Noonan <steven@uplinklabs.net>